### PR TITLE
feat: XGBSEStackedWeibull

### DIFF
--- a/examples/benchmarks/benchmarks_flchain.ipynb
+++ b/examples/benchmarks/benchmarks_flchain.ipynb
@@ -3,19 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# autoreload\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,12 +16,12 @@
     "import xgboost as xgb\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator\n",
+    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator, XGBSEStackedWeibull\n",
     "from xgbse.converters import convert_data_to_xgb_format, convert_to_structured, convert_y\n",
     "from xgbse.non_parametric import get_time_bins\n",
     "\n",
     "from benchmark import BenchmarkLifelines, BenchmarkXGBoost, BenchmarkXGBSE, BenchmarkPysurvival\n",
-    "from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
+    "#from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
     "\n",
     "# setting seed\n",
     "np.random.seed(42)"
@@ -42,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,11 +48,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset 'flchain' not locally available. Downloading...\n",
+      "Done\n"
+     ]
+    }
+   ],
    "source": [
     "from pycox.datasets import flchain\n",
     "df = flchain.read_df()\n",
@@ -90,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -143,11 +139,11 @@
        " 'ibs': 0.0985487804655452,\n",
        " 'dcal_pval': 0.9711460792177572,\n",
        " 'dcal_max_dev': 0.0113195501393272,\n",
-       " 'training_time': 1.192168951034546,\n",
-       " 'inference_time': 0.006709098815917969}"
+       " 'training_time': 0.9423878192901611,\n",
+       " 'inference_time': 0.004564046859741211}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "tags": []
    },
@@ -195,14 +191,14 @@
       "text/plain": [
        "{'model': 'Weibull AFT',\n",
        " 'c-index': 0.788764446796106,\n",
-       " 'ibs': 0.09899526138314266,\n",
-       " 'dcal_pval': 0.8485679576992691,\n",
-       " 'dcal_max_dev': 0.0130897512621993,\n",
-       " 'training_time': 0.8402612209320068,\n",
-       " 'inference_time': 0.010332822799682617}"
+       " 'ibs': 0.09899526138319895,\n",
+       " 'dcal_pval': 0.8485679576993114,\n",
+       " 'dcal_max_dev': 0.013089751262202395,\n",
+       " 'training_time': 0.5366322994232178,\n",
+       " 'inference_time': 0.005728960037231445}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "tags": []
    },
@@ -258,15 +254,15 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - AFT',\n",
-       " 'c-index': 0.7815428859787077,\n",
+       " 'c-index': 0.771647534919725,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.06519603729248047,\n",
-       " 'inference_time': 0.0008289813995361328}"
+       " 'training_time': 0.1057589054107666,\n",
+       " 'inference_time': 0.0008881092071533203}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,22 +284,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'model': 'XGB - Cox',\n",
-       " 'c-index': 0.7786192316925594,\n",
+       " 'c-index': 0.7748247277216809,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.0846090316772461,\n",
-       " 'inference_time': 0.0008230209350585938}"
+       " 'training_time': 0.05382394790649414,\n",
+       " 'inference_time': 0.0006210803985595703}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -326,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,22 +338,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Debiased BCE',\n",
-       " 'c-index': 0.7841321633816893,\n",
-       " 'ibs': 0.1013538111648455,\n",
-       " 'dcal_pval': 0.03644799466710443,\n",
-       " 'dcal_max_dev': 0.0298175545947673,\n",
-       " 'training_time': 46.155426025390625,\n",
-       " 'inference_time': 0.47022414207458496}"
+       " 'c-index': 0.7843379337713303,\n",
+       " 'ibs': 0.11658577957742053,\n",
+       " 'dcal_pval': 6.499812880315087e-05,\n",
+       " 'dcal_max_dev': 0.03715199563137006,\n",
+       " 'training_time': 3.061776876449585,\n",
+       " 'inference_time': 0.23334813117980957}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,22 +385,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Kaplan Neighbors',\n",
-       " 'c-index': 0.7694232549936064,\n",
-       " 'ibs': 0.10297238924307031,\n",
-       " 'dcal_pval': 0.7320452038855624,\n",
-       " 'dcal_max_dev': 0.019724969746333948,\n",
-       " 'training_time': 31.365705966949463,\n",
-       " 'inference_time': 5.807218074798584}"
+       " 'c-index': 0.7765872490948552,\n",
+       " 'ibs': 0.10166555304551815,\n",
+       " 'dcal_pval': 0.9177066941432961,\n",
+       " 'dcal_max_dev': 0.012590080176862473,\n",
+       " 'training_time': 0.47940921783447266,\n",
+       " 'inference_time': 0.542578935623169}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -447,11 +443,11 @@
        " 'ibs': 0.10346911400864475,\n",
        " 'dcal_pval': 0.9287914257772109,\n",
        " 'dcal_max_dev': 0.01106687028007211,\n",
-       " 'training_time': 0.21167683601379395,\n",
-       " 'inference_time': 0.0029299259185791016}"
+       " 'training_time': 0.16666603088378906,\n",
+       " 'inference_time': 0.003175973892211914}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -474,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {
     "tags": []
    },
@@ -485,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -496,11 +492,11 @@
        " 'ibs': 0.10047335035894789,\n",
        " 'dcal_pval': 0.9845121854944557,\n",
        " 'dcal_max_dev': 0.009485243521309514,\n",
-       " 'training_time': 17.497756004333496,\n",
-       " 'inference_time': 0.4245340824127197}"
+       " 'training_time': 15.351151943206787,\n",
+       " 'inference_time': 0.382260799407959}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,62 +530,55 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pysurvival"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'model': 'Conditional Survival Forest',\n",
-       " 'c-index': 0.7614202566250716,\n",
-       " 'ibs': 0.10590986997908104,\n",
-       " 'dcal_pval': 0.03091278345062742,\n",
-       " 'dcal_max_dev': 0.029681239567899267,\n",
-       " 'training_time': 1.1027400493621826,\n",
-       " 'inference_time': 109.55284905433655}"
+       "{'model': 'XGBSE - Stacked Weibull',\n",
+       " 'c-index': 0.7763582070540049,\n",
+       " 'ibs': 0.10295151190387516,\n",
+       " 'dcal_pval': 0.993686931213167,\n",
+       " 'dcal_max_dev': 0.007788526213200461,\n",
+       " 'training_time': 0.7186770439147949,\n",
+       " 'inference_time': 0.011139869689941406}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "bench_pysurvival = BenchmarkPysurvival(ConditionalSurvivalForestModel(),\n",
+    "bench_xgboost_embedding = BenchmarkXGBSE(XGBSEStackedWeibull(),\n",
     "        df_train,\n",
     "        df_valid,\n",
     "        df_test,\n",
     "        \"event\",\n",
     "        \"duration\",\n",
     "        TIME_BINS,\n",
-    "        \"Conditional Survival Forest\",\n",
-    "\n",
+    "        \"XGBSE - Stacked Weibull\",\n",
+    "        \"survival:aft\",\n",
     ")\n",
-    "bench_pysurvival.train()\n",
-    "pysurvival_results = bench_pysurvival.test()\n",
-    "pysurvival_results"
+    "bench_xgboost_embedding.train()\n",
+    "xgboost_weibull_results = bench_xgboost_embedding.test()\n",
+    "xgboost_weibull_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = results.append(xgboost_weibull_results, ignore_index=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results = results.append(pysurvival_results, ignore_index=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -629,9 +618,9 @@
        "      <td>0.013</td>\n",
        "      <td>0.849</td>\n",
        "      <td>0.099</td>\n",
-       "      <td>0.010</td>\n",
+       "      <td>0.006</td>\n",
        "      <td>Weibull AFT</td>\n",
-       "      <td>0.840</td>\n",
+       "      <td>0.537</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
@@ -639,29 +628,19 @@
        "      <td>0.011</td>\n",
        "      <td>0.971</td>\n",
        "      <td>0.099</td>\n",
-       "      <td>0.007</td>\n",
+       "      <td>0.005</td>\n",
        "      <td>Cox-PH</td>\n",
-       "      <td>1.192</td>\n",
+       "      <td>0.942</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0.784</td>\n",
-       "      <td>0.030</td>\n",
-       "      <td>0.036</td>\n",
-       "      <td>0.101</td>\n",
-       "      <td>0.470</td>\n",
+       "      <td>0.037</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.117</td>\n",
+       "      <td>0.233</td>\n",
        "      <td>XGBSE - Debiased BCE</td>\n",
-       "      <td>46.155</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.782</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>XGB - AFT</td>\n",
-       "      <td>0.065</td>\n",
+       "      <td>3.062</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -669,29 +648,49 @@
        "      <td>0.009</td>\n",
        "      <td>0.985</td>\n",
        "      <td>0.100</td>\n",
-       "      <td>0.425</td>\n",
+       "      <td>0.382</td>\n",
        "      <td>XGBSE - Bootstrap Trees</td>\n",
-       "      <td>17.498</td>\n",
+       "      <td>15.351</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.777</td>\n",
+       "      <td>0.013</td>\n",
+       "      <td>0.918</td>\n",
+       "      <td>0.102</td>\n",
+       "      <td>0.543</td>\n",
+       "      <td>XGBSE - Kaplan Neighbors</td>\n",
+       "      <td>0.479</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.776</td>\n",
+       "      <td>0.008</td>\n",
+       "      <td>0.994</td>\n",
+       "      <td>0.103</td>\n",
+       "      <td>0.011</td>\n",
+       "      <td>XGBSE - Stacked Weibull</td>\n",
+       "      <td>0.719</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.779</td>\n",
+       "      <td>0.775</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - Cox</td>\n",
-       "      <td>0.085</td>\n",
+       "      <td>0.054</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>0.769</td>\n",
-       "      <td>0.020</td>\n",
-       "      <td>0.732</td>\n",
-       "      <td>0.103</td>\n",
-       "      <td>5.807</td>\n",
-       "      <td>XGBSE - Kaplan Neighbors</td>\n",
-       "      <td>31.366</td>\n",
+       "      <th>2</th>\n",
+       "      <td>0.772</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>XGB - AFT</td>\n",
+       "      <td>0.106</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -701,17 +700,7 @@
        "      <td>0.103</td>\n",
        "      <td>0.003</td>\n",
        "      <td>XGBSE - Kaplan Tree</td>\n",
-       "      <td>0.212</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.761</td>\n",
-       "      <td>0.030</td>\n",
-       "      <td>0.031</td>\n",
-       "      <td>0.106</td>\n",
-       "      <td>109.553</td>\n",
-       "      <td>Conditional Survival Forest</td>\n",
-       "      <td>1.103</td>\n",
+       "      <td>0.167</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -719,29 +708,29 @@
       ],
       "text/plain": [
        "   c-index  dcal_max_dev  dcal_pval    ibs  inference_time  \\\n",
-       "1    0.789         0.013      0.849  0.099           0.010   \n",
-       "0    0.788         0.011      0.971  0.099           0.007   \n",
-       "4    0.784         0.030      0.036  0.101           0.470   \n",
-       "2    0.782           NaN        NaN    NaN           0.001   \n",
-       "7    0.781         0.009      0.985  0.100           0.425   \n",
-       "3    0.779           NaN        NaN    NaN           0.001   \n",
-       "5    0.769         0.020      0.732  0.103           5.807   \n",
+       "1    0.789         0.013      0.849  0.099           0.006   \n",
+       "0    0.788         0.011      0.971  0.099           0.005   \n",
+       "4    0.784         0.037      0.000  0.117           0.233   \n",
+       "7    0.781         0.009      0.985  0.100           0.382   \n",
+       "5    0.777         0.013      0.918  0.102           0.543   \n",
+       "8    0.776         0.008      0.994  0.103           0.011   \n",
+       "3    0.775           NaN        NaN    NaN           0.001   \n",
+       "2    0.772           NaN        NaN    NaN           0.001   \n",
        "6    0.768         0.011      0.929  0.103           0.003   \n",
-       "8    0.761         0.030      0.031  0.106         109.553   \n",
        "\n",
-       "                         model  training_time  \n",
-       "1                  Weibull AFT          0.840  \n",
-       "0                       Cox-PH          1.192  \n",
-       "4         XGBSE - Debiased BCE         46.155  \n",
-       "2                    XGB - AFT          0.065  \n",
-       "7      XGBSE - Bootstrap Trees         17.498  \n",
-       "3                    XGB - Cox          0.085  \n",
-       "5     XGBSE - Kaplan Neighbors         31.366  \n",
-       "6          XGBSE - Kaplan Tree          0.212  \n",
-       "8  Conditional Survival Forest          1.103  "
+       "                      model  training_time  \n",
+       "1               Weibull AFT          0.537  \n",
+       "0                    Cox-PH          0.942  \n",
+       "4      XGBSE - Debiased BCE          3.062  \n",
+       "7   XGBSE - Bootstrap Trees         15.351  \n",
+       "5  XGBSE - Kaplan Neighbors          0.479  \n",
+       "8   XGBSE - Stacked Weibull          0.719  \n",
+       "3                 XGB - Cox          0.054  \n",
+       "2                 XGB - AFT          0.106  \n",
+       "6       XGBSE - Kaplan Tree          0.167  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -752,21 +741,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'| model                       |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:----------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| Weibull AFT                 |     0.789 |          0.013 |       0.849 |   0.099 |            0.01  |           0.84  |\\n| Cox-PH                      |     0.788 |          0.011 |       0.971 |   0.099 |            0.007 |           1.192 |\\n| XGBSE - Debiased BCE        |     0.784 |          0.03  |       0.036 |   0.101 |            0.47  |          46.155 |\\n| XGB - AFT                   |     0.782 |        nan     |     nan     | nan     |            0.001 |           0.065 |\\n| XGBSE - Bootstrap Trees     |     0.781 |          0.009 |       0.985 |   0.1   |            0.425 |          17.498 |\\n| XGB - Cox                   |     0.779 |        nan     |     nan     | nan     |            0.001 |           0.085 |\\n| XGBSE - Kaplan Neighbors    |     0.769 |          0.02  |       0.732 |   0.103 |            5.807 |          31.366 |\\n| XGBSE - Kaplan Tree         |     0.768 |          0.011 |       0.929 |   0.103 |            0.003 |           0.212 |\\n| Conditional Survival Forest |     0.761 |          0.03  |       0.031 |   0.106 |          109.553 |           1.103 |'"
+       "'| model                    |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:-------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| Weibull AFT              |     0.789 |          0.013 |       0.849 |   0.099 |            0.006 |           0.537 |\\n| Cox-PH                   |     0.788 |          0.011 |       0.971 |   0.099 |            0.005 |           0.942 |\\n| XGBSE - Debiased BCE     |     0.784 |          0.037 |       0     |   0.117 |            0.233 |           3.062 |\\n| XGBSE - Bootstrap Trees  |     0.781 |          0.009 |       0.985 |   0.1   |            0.382 |          15.351 |\\n| XGBSE - Kaplan Neighbors |     0.777 |          0.013 |       0.918 |   0.102 |            0.543 |           0.479 |\\n| XGBSE - Stacked Weibull  |     0.776 |          0.008 |       0.994 |   0.103 |            0.011 |           0.719 |\\n| XGB - Cox                |     0.775 |        nan     |     nan     | nan     |            0.001 |           0.054 |\\n| XGB - AFT                |     0.772 |        nan     |     nan     | nan     |            0.001 |           0.106 |\\n| XGBSE - Kaplan Tree      |     0.768 |          0.011 |       0.929 |   0.103 |            0.003 |           0.167 |'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "import tabulate\n",
     "results.sort_values(\"c-index\", ascending=False).round(3).set_index('model').to_markdown()"
    ]
   },
@@ -836,9 +826,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:xgbse]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-xgbse-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -850,7 +840,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/examples/benchmarks/benchmarks_metabric.ipynb
+++ b/examples/benchmarks/benchmarks_metabric.ipynb
@@ -29,12 +29,12 @@
     "import xgboost as xgb\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator\n",
+    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator, XGBSEStackedWeibull\n",
     "from xgbse.converters import convert_data_to_xgb_format, convert_to_structured, convert_y\n",
     "from xgbse.non_parametric import get_time_bins\n",
     "\n",
     "from benchmark import BenchmarkLifelines, BenchmarkXGBoost, BenchmarkXGBSE, BenchmarkPysurvival\n",
-    "from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
+    "#from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
     "\n",
     "# setting seed\n",
     "np.random.seed(42)"
@@ -65,7 +65,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset 'metabric' not locally available. Downloading...\n",
+      "Done\n"
+     ]
+    }
+   ],
    "source": [
     "from pycox.datasets import metabric\n",
     "metabric_df = metabric.read_df()\n",
@@ -138,11 +147,11 @@
       "text/plain": [
        "{'model': 'Cox-PH',\n",
        " 'c-index': 0.6216153910637942,\n",
-       " 'ibs': 0.15360476043227422,\n",
-       " 'dcal_pval': 0.5666124375648811,\n",
-       " 'dcal_max_dev': 0.025805768690018743,\n",
-       " 'training_time': 0.21692919731140137,\n",
-       " 'inference_time': 0.004318952560424805}"
+       " 'ibs': 0.1536047604322741,\n",
+       " 'dcal_pval': 0.5666124375648869,\n",
+       " 'dcal_max_dev': 0.02580576869001855,\n",
+       " 'training_time': 0.24448299407958984,\n",
+       " 'inference_time': 0.003534078598022461}"
       ]
      },
      "execution_count": 8,
@@ -193,11 +202,11 @@
       "text/plain": [
        "{'model': 'Weibull AFT',\n",
        " 'c-index': 0.6221812389974013,\n",
-       " 'ibs': 0.15412227274195567,\n",
-       " 'dcal_pval': 0.666759786591344,\n",
-       " 'dcal_max_dev': 0.024245639416549558,\n",
-       " 'training_time': 0.3900749683380127,\n",
-       " 'inference_time': 0.00800180435180664}"
+       " 'ibs': 0.15412227274195364,\n",
+       " 'dcal_pval': 0.6667597865912567,\n",
+       " 'dcal_max_dev': 0.02424563941655307,\n",
+       " 'training_time': 0.283588171005249,\n",
+       " 'inference_time': 0.0049610137939453125}"
       ]
      },
      "execution_count": 11,
@@ -256,12 +265,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - AFT',\n",
-       " 'c-index': 0.6101726884064046,\n",
+       " 'c-index': 0.5995054069913656,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.02436208724975586,\n",
-       " 'inference_time': 0.0007061958312988281}"
+       " 'training_time': 0.04438591003417969,\n",
+       " 'inference_time': 0.0007588863372802734}"
       ]
      },
      "execution_count": 14,
@@ -293,12 +302,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - Cox',\n",
-       " 'c-index': 0.6192157766786822,\n",
+       " 'c-index': 0.6166275463157013,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.022723913192749023,\n",
-       " 'inference_time': 0.0006630420684814453}"
+       " 'training_time': 0.09560084342956543,\n",
+       " 'inference_time': 0.0006392002105712891}"
       ]
      },
      "execution_count": 16,
@@ -347,12 +356,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Debiased BCE',\n",
-       " 'c-index': 0.6322198004862101,\n",
-       " 'ibs': 0.1566039133167816,\n",
-       " 'dcal_pval': 0.3811202061981239,\n",
-       " 'dcal_max_dev': 0.03232402429331624,\n",
-       " 'training_time': 14.198437929153442,\n",
-       " 'inference_time': 0.36887192726135254}"
+       " 'c-index': 0.626791851789756,\n",
+       " 'ibs': 0.16544718820181464,\n",
+       " 'dcal_pval': 0.1282159506899636,\n",
+       " 'dcal_max_dev': 0.03267038833783695,\n",
+       " 'training_time': 3.1647579669952393,\n",
+       " 'inference_time': 0.0900719165802002}"
       ]
      },
      "execution_count": 18,
@@ -394,12 +403,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Kaplan Neighbors',\n",
-       " 'c-index': 0.6269595104367508,\n",
-       " 'ibs': 0.15569091727108705,\n",
-       " 'dcal_pval': 0.52481525977227,\n",
-       " 'dcal_max_dev': 0.02351833078188803,\n",
-       " 'training_time': 25.679295301437378,\n",
-       " 'inference_time': 0.7914042472839355}"
+       " 'c-index': 0.605205800989186,\n",
+       " 'ibs': 0.1626562183639951,\n",
+       " 'dcal_pval': 0.5884955731415418,\n",
+       " 'dcal_max_dev': 0.022632881520071785,\n",
+       " 'training_time': 0.15366601943969727,\n",
+       " 'inference_time': 0.11072587966918945}"
       ]
      },
      "execution_count": 20,
@@ -445,8 +454,8 @@
        " 'ibs': 0.16482640216664288,\n",
        " 'dcal_pval': 0.18030272928223431,\n",
        " 'dcal_max_dev': 0.03586345646948624,\n",
-       " 'training_time': 0.1144261360168457,\n",
-       " 'inference_time': 0.01436305046081543}"
+       " 'training_time': 0.04992818832397461,\n",
+       " 'inference_time': 0.0022470951080322266}"
       ]
      },
      "execution_count": 22,
@@ -494,8 +503,8 @@
        " 'ibs': 0.1549380947038349,\n",
        " 'dcal_pval': 0.5634196757562135,\n",
        " 'dcal_max_dev': 0.023621561823879617,\n",
-       " 'training_time': 11.956449031829834,\n",
-       " 'inference_time': 0.4664280414581299}"
+       " 'training_time': 6.165475845336914,\n",
+       " 'inference_time': 0.300656795501709}"
       ]
      },
      "execution_count": 24,
@@ -532,13 +541,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pysurvival"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
@@ -546,13 +548,13 @@
     {
      "data": {
       "text/plain": [
-       "{'model': 'Conditional Survival Forest',\n",
-       " 'c-index': 0.6233129348646157,\n",
-       " 'ibs': 0.15248870955612373,\n",
-       " 'dcal_pval': 0.28919180650906656,\n",
-       " 'dcal_max_dev': 0.03175346126555047,\n",
-       " 'training_time': 0.20072293281555176,\n",
-       " 'inference_time': 31.874172925949097}"
+       "{'model': 'XGBSE - Stacked Weibull',\n",
+       " 'c-index': 0.629809707435661,\n",
+       " 'ibs': 0.16175955116529236,\n",
+       " 'dcal_pval': 0.14584322589592966,\n",
+       " 'dcal_max_dev': 0.04453524769696715,\n",
+       " 'training_time': 0.5253489017486572,\n",
+       " 'inference_time': 0.009682178497314453}"
       ]
      },
      "execution_count": 26,
@@ -561,19 +563,19 @@
     }
    ],
    "source": [
-    "bench_pysurvival = BenchmarkPysurvival(ConditionalSurvivalForestModel(),\n",
+    "bench_xgboost_embedding = BenchmarkXGBSE(XGBSEStackedWeibull(),\n",
     "        df_train,\n",
     "        df_valid,\n",
     "        df_test,\n",
     "        \"event\",\n",
     "        \"duration\",\n",
     "        TIME_BINS,\n",
-    "        \"Conditional Survival Forest\",\n",
-    "\n",
+    "        \"XGBSE - Stacked Weibull\",\n",
+    "        \"survival:aft\",\n",
     ")\n",
-    "bench_pysurvival.train()\n",
-    "pysurvival_results = bench_pysurvival.test()\n",
-    "pysurvival_results"
+    "bench_xgboost_embedding.train()\n",
+    "xgboost_weibull_results = bench_xgboost_embedding.test()\n",
+    "xgboost_weibull_results"
    ]
   },
   {
@@ -582,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = results.append(pysurvival_results, ignore_index=True)"
+    "results = results.append(xgboost_weibull_results, ignore_index=True)"
    ]
   },
   {
@@ -622,24 +624,24 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.632</td>\n",
-       "      <td>0.032</td>\n",
-       "      <td>0.381</td>\n",
-       "      <td>0.157</td>\n",
-       "      <td>0.369</td>\n",
-       "      <td>XGBSE - Debiased BCE</td>\n",
-       "      <td>14.198</td>\n",
+       "      <th>8</th>\n",
+       "      <td>0.630</td>\n",
+       "      <td>0.045</td>\n",
+       "      <td>0.146</td>\n",
+       "      <td>0.162</td>\n",
+       "      <td>0.010</td>\n",
+       "      <td>XGBSE - Stacked Weibull</td>\n",
+       "      <td>0.525</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>4</th>\n",
        "      <td>0.627</td>\n",
-       "      <td>0.024</td>\n",
-       "      <td>0.525</td>\n",
-       "      <td>0.156</td>\n",
-       "      <td>0.791</td>\n",
-       "      <td>XGBSE - Kaplan Neighbors</td>\n",
-       "      <td>25.679</td>\n",
+       "      <td>0.033</td>\n",
+       "      <td>0.128</td>\n",
+       "      <td>0.165</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>XGBSE - Debiased BCE</td>\n",
+       "      <td>3.165</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -647,19 +649,9 @@
        "      <td>0.024</td>\n",
        "      <td>0.563</td>\n",
        "      <td>0.155</td>\n",
-       "      <td>0.466</td>\n",
+       "      <td>0.301</td>\n",
        "      <td>XGBSE - Bootstrap Trees</td>\n",
-       "      <td>11.956</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.623</td>\n",
-       "      <td>0.032</td>\n",
-       "      <td>0.289</td>\n",
-       "      <td>0.152</td>\n",
-       "      <td>31.874</td>\n",
-       "      <td>Conditional Survival Forest</td>\n",
-       "      <td>0.201</td>\n",
+       "      <td>6.165</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -667,9 +659,9 @@
        "      <td>0.024</td>\n",
        "      <td>0.667</td>\n",
        "      <td>0.154</td>\n",
-       "      <td>0.008</td>\n",
+       "      <td>0.005</td>\n",
        "      <td>Weibull AFT</td>\n",
-       "      <td>0.390</td>\n",
+       "      <td>0.284</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
@@ -679,27 +671,37 @@
        "      <td>0.154</td>\n",
        "      <td>0.004</td>\n",
        "      <td>Cox-PH</td>\n",
-       "      <td>0.217</td>\n",
+       "      <td>0.244</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.619</td>\n",
+       "      <td>0.617</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - Cox</td>\n",
+       "      <td>0.096</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.605</td>\n",
        "      <td>0.023</td>\n",
+       "      <td>0.588</td>\n",
+       "      <td>0.163</td>\n",
+       "      <td>0.111</td>\n",
+       "      <td>XGBSE - Kaplan Neighbors</td>\n",
+       "      <td>0.154</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.610</td>\n",
+       "      <td>0.600</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - AFT</td>\n",
-       "      <td>0.024</td>\n",
+       "      <td>0.044</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -707,9 +709,9 @@
        "      <td>0.036</td>\n",
        "      <td>0.180</td>\n",
        "      <td>0.165</td>\n",
-       "      <td>0.014</td>\n",
+       "      <td>0.002</td>\n",
        "      <td>XGBSE - Kaplan Tree</td>\n",
-       "      <td>0.114</td>\n",
+       "      <td>0.050</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -717,26 +719,26 @@
       ],
       "text/plain": [
        "   c-index  dcal_max_dev  dcal_pval    ibs  inference_time  \\\n",
-       "4    0.632         0.032      0.381  0.157           0.369   \n",
-       "5    0.627         0.024      0.525  0.156           0.791   \n",
-       "7    0.624         0.024      0.563  0.155           0.466   \n",
-       "8    0.623         0.032      0.289  0.152          31.874   \n",
-       "1    0.622         0.024      0.667  0.154           0.008   \n",
+       "8    0.630         0.045      0.146  0.162           0.010   \n",
+       "4    0.627         0.033      0.128  0.165           0.090   \n",
+       "7    0.624         0.024      0.563  0.155           0.301   \n",
+       "1    0.622         0.024      0.667  0.154           0.005   \n",
        "0    0.622         0.026      0.567  0.154           0.004   \n",
-       "3    0.619           NaN        NaN    NaN           0.001   \n",
-       "2    0.610           NaN        NaN    NaN           0.001   \n",
-       "6    0.590         0.036      0.180  0.165           0.014   \n",
+       "3    0.617           NaN        NaN    NaN           0.001   \n",
+       "5    0.605         0.023      0.588  0.163           0.111   \n",
+       "2    0.600           NaN        NaN    NaN           0.001   \n",
+       "6    0.590         0.036      0.180  0.165           0.002   \n",
        "\n",
-       "                         model  training_time  \n",
-       "4         XGBSE - Debiased BCE         14.198  \n",
-       "5     XGBSE - Kaplan Neighbors         25.679  \n",
-       "7      XGBSE - Bootstrap Trees         11.956  \n",
-       "8  Conditional Survival Forest          0.201  \n",
-       "1                  Weibull AFT          0.390  \n",
-       "0                       Cox-PH          0.217  \n",
-       "3                    XGB - Cox          0.023  \n",
-       "2                    XGB - AFT          0.024  \n",
-       "6          XGBSE - Kaplan Tree          0.114  "
+       "                      model  training_time  \n",
+       "8   XGBSE - Stacked Weibull          0.525  \n",
+       "4      XGBSE - Debiased BCE          3.165  \n",
+       "7   XGBSE - Bootstrap Trees          6.165  \n",
+       "1               Weibull AFT          0.284  \n",
+       "0                    Cox-PH          0.244  \n",
+       "3                 XGB - Cox          0.096  \n",
+       "5  XGBSE - Kaplan Neighbors          0.154  \n",
+       "2                 XGB - AFT          0.044  \n",
+       "6       XGBSE - Kaplan Tree          0.050  "
       ]
      },
      "execution_count": 28,
@@ -756,7 +758,7 @@
     {
      "data": {
       "text/plain": [
-       "'| model                       |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:----------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Debiased BCE        |     0.632 |          0.032 |       0.381 |   0.157 |            0.369 |          14.198 |\\n| XGBSE - Kaplan Neighbors    |     0.627 |          0.024 |       0.525 |   0.156 |            0.791 |          25.679 |\\n| XGBSE - Bootstrap Trees     |     0.624 |          0.024 |       0.563 |   0.155 |            0.466 |          11.956 |\\n| Conditional Survival Forest |     0.623 |          0.032 |       0.289 |   0.152 |           31.874 |           0.201 |\\n| Weibull AFT                 |     0.622 |          0.024 |       0.667 |   0.154 |            0.008 |           0.39  |\\n| Cox-PH                      |     0.622 |          0.026 |       0.567 |   0.154 |            0.004 |           0.217 |\\n| XGB - Cox                   |     0.619 |        nan     |     nan     | nan     |            0.001 |           0.023 |\\n| XGB - AFT                   |     0.61  |        nan     |     nan     | nan     |            0.001 |           0.024 |\\n| XGBSE - Kaplan Tree         |     0.59  |          0.036 |       0.18  |   0.165 |            0.014 |           0.114 |'"
+       "'| model                    |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:-------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Stacked Weibull  |     0.63  |          0.045 |       0.146 |   0.162 |            0.01  |           0.525 |\\n| XGBSE - Debiased BCE     |     0.627 |          0.033 |       0.128 |   0.165 |            0.09  |           3.165 |\\n| XGBSE - Bootstrap Trees  |     0.624 |          0.024 |       0.563 |   0.155 |            0.301 |           6.165 |\\n| Weibull AFT              |     0.622 |          0.024 |       0.667 |   0.154 |            0.005 |           0.284 |\\n| Cox-PH                   |     0.622 |          0.026 |       0.567 |   0.154 |            0.004 |           0.244 |\\n| XGB - Cox                |     0.617 |        nan     |     nan     | nan     |            0.001 |           0.096 |\\n| XGBSE - Kaplan Neighbors |     0.605 |          0.023 |       0.588 |   0.163 |            0.111 |           0.154 |\\n| XGB - AFT                |     0.6   |        nan     |     nan     | nan     |            0.001 |           0.044 |\\n| XGBSE - Kaplan Tree      |     0.59  |          0.036 |       0.18  |   0.165 |            0.002 |           0.05  |'"
       ]
      },
      "execution_count": 29,
@@ -834,9 +836,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:xgbse]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-xgbse-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -848,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/examples/benchmarks/benchmarks_rr_nl_nhp.ipynb
+++ b/examples/benchmarks/benchmarks_rr_nl_nhp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -29,12 +29,12 @@
     "import xgboost as xgb\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator\n",
+    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator, XGBSEStackedWeibull\n",
     "from xgbse.converters import convert_data_to_xgb_format, convert_to_structured, convert_y\n",
     "from xgbse.non_parametric import get_time_bins\n",
     "\n",
     "from benchmark import BenchmarkLifelines, BenchmarkXGBoost, BenchmarkXGBSE, BenchmarkPysurvival\n",
-    "from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
+    "#from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
     "\n",
     "# setting seed\n",
     "np.random.seed(42)"
@@ -65,7 +65,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset 'rr_nl_nph' not created yet. Making dataset...\n",
+      "Done\n"
+     ]
+    }
+   ],
    "source": [
     "from pycox.datasets import rr_nl_nhp\n",
     "df = rr_nl_nhp.read_df()\n",
@@ -141,8 +150,8 @@
        " 'ibs': 0.13529809371549895,\n",
        " 'dcal_pval': 4.498777173708728e-43,\n",
        " 'dcal_max_dev': 0.054902674947442935,\n",
-       " 'training_time': 2.3615710735321045,\n",
-       " 'inference_time': 0.011093854904174805}"
+       " 'training_time': 2.267102003097534,\n",
+       " 'inference_time': 0.020849943161010742}"
       ]
      },
      "execution_count": 8,
@@ -194,10 +203,10 @@
        "{'model': 'Weibull AFT',\n",
        " 'c-index': 0.7868933380115156,\n",
        " 'ibs': 0.13602422693625488,\n",
-       " 'dcal_pval': 2.880925330169667e-43,\n",
-       " 'dcal_max_dev': 0.05667257626985076,\n",
-       " 'training_time': 0.26163506507873535,\n",
-       " 'inference_time': 0.008216142654418945}"
+       " 'dcal_pval': 2.8809253301697514e-43,\n",
+       " 'dcal_max_dev': 0.056672576269850755,\n",
+       " 'training_time': 0.32565784454345703,\n",
+       " 'inference_time': 0.009634017944335938}"
       ]
      },
      "execution_count": 11,
@@ -256,12 +265,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - AFT',\n",
-       " 'c-index': 0.8247420038146053,\n",
+       " 'c-index': 0.8234768714689867,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.050727128982543945,\n",
-       " 'inference_time': 0.0007798671722412109}"
+       " 'training_time': 0.242509126663208,\n",
+       " 'inference_time': 0.0011980533599853516}"
       ]
      },
      "execution_count": 14,
@@ -293,12 +302,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - Cox',\n",
-       " 'c-index': 0.8256438268849773,\n",
+       " 'c-index': 0.8235333028955971,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.0559542179107666,\n",
-       " 'inference_time': 0.0006079673767089844}"
+       " 'training_time': 0.37476611137390137,\n",
+       " 'inference_time': 0.001577138900756836}"
       ]
      },
      "execution_count": 16,
@@ -347,12 +356,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Debiased BCE',\n",
-       " 'c-index': 0.8269204387353041,\n",
-       " 'ibs': 0.09752739549146452,\n",
-       " 'dcal_pval': 5.8911349042153576e-61,\n",
-       " 'dcal_max_dev': 0.04365250295331396,\n",
-       " 'training_time': 128.98045086860657,\n",
-       " 'inference_time': 0.9824099540710449}"
+       " 'c-index': 0.8242329843904878,\n",
+       " 'ibs': 0.10829539841030063,\n",
+       " 'dcal_pval': 2.3686030061958938e-135,\n",
+       " 'dcal_max_dev': 0.0683270751610485,\n",
+       " 'training_time': 4.561779975891113,\n",
+       " 'inference_time': 0.2850668430328369}"
       ]
      },
      "execution_count": 18,
@@ -394,12 +403,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Kaplan Neighbors',\n",
-       " 'c-index': 0.8225066828334464,\n",
-       " 'ibs': 0.09971237872316244,\n",
-       " 'dcal_pval': 3.219039393014018e-30,\n",
-       " 'dcal_max_dev': 0.03427276372407928,\n",
-       " 'training_time': 112.96890211105347,\n",
-       " 'inference_time': 66.89054703712463}"
+       " 'c-index': 0.8243235133558354,\n",
+       " 'ibs': 0.09968222364315912,\n",
+       " 'dcal_pval': 6.1562943589818576e-34,\n",
+       " 'dcal_max_dev': 0.037758403022887965,\n",
+       " 'training_time': 1.5040209293365479,\n",
+       " 'inference_time': 15.661872863769531}"
       ]
      },
      "execution_count": 20,
@@ -445,8 +454,8 @@
        " 'ibs': 0.10129775993937155,\n",
        " 'dcal_pval': 6.905144620707361e-44,\n",
        " 'dcal_max_dev': 0.043777519983996954,\n",
-       " 'training_time': 0.5062479972839355,\n",
-       " 'inference_time': 0.004987955093383789}"
+       " 'training_time': 0.489609956741333,\n",
+       " 'inference_time': 0.006279945373535156}"
       ]
      },
      "execution_count": 22,
@@ -494,8 +503,8 @@
        " 'ibs': 0.09713889680012697,\n",
        " 'dcal_pval': 1.4238032769395418e-34,\n",
        " 'dcal_max_dev': 0.035288583245685845,\n",
-       " 'training_time': 40.94499111175537,\n",
-       " 'inference_time': 0.4194779396057129}"
+       " 'training_time': 44.73573398590088,\n",
+       " 'inference_time': 0.5337009429931641}"
       ]
      },
      "execution_count": 24,
@@ -532,13 +541,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pysurvival"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
@@ -546,13 +548,13 @@
     {
      "data": {
       "text/plain": [
-       "{'model': 'Conditional Survival Forest',\n",
-       " 'c-index': 0.8107541136691464,\n",
-       " 'ibs': 0.11349372155633686,\n",
-       " 'dcal_pval': 1.8236116793086885e-108,\n",
-       " 'dcal_max_dev': 0.06696904963665812,\n",
-       " 'training_time': 17.024398803710938,\n",
-       " 'inference_time': 5786.263374090195}"
+       "{'model': 'XGBSE - Stacked Weibull',\n",
+       " 'c-index': 0.8263715251908638,\n",
+       " 'ibs': 0.11344542750597256,\n",
+       " 'dcal_pval': 1.2434514782345034e-79,\n",
+       " 'dcal_max_dev': 0.05042037645542169,\n",
+       " 'training_time': 2.2547810077667236,\n",
+       " 'inference_time': 0.019007205963134766}"
       ]
      },
      "execution_count": 26,
@@ -561,19 +563,19 @@
     }
    ],
    "source": [
-    "bench_pysurvival = BenchmarkPysurvival(ConditionalSurvivalForestModel(),\n",
+    "bench_xgboost_embedding = BenchmarkXGBSE(XGBSEStackedWeibull(),\n",
     "        df_train,\n",
     "        df_valid,\n",
     "        df_test,\n",
     "        \"event\",\n",
     "        \"duration\",\n",
     "        TIME_BINS,\n",
-    "        \"Conditional Survival Forest\",\n",
-    "\n",
+    "        \"XGBSE - Stacked Weibull\",\n",
+    "        \"survival:aft\",\n",
     ")\n",
-    "bench_pysurvival.train()\n",
-    "pysurvival_results = bench_pysurvival.test()\n",
-    "pysurvival_results"
+    "bench_xgboost_embedding.train()\n",
+    "xgboost_weibull_results = bench_xgboost_embedding.test()\n",
+    "xgboost_weibull_results"
    ]
   },
   {
@@ -582,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = results.append(pysurvival_results, ignore_index=True)"
+    "results = results.append(xgboost_weibull_results, ignore_index=True)"
    ]
   },
   {
@@ -622,14 +624,14 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.827</td>\n",
-       "      <td>0.044</td>\n",
+       "      <th>8</th>\n",
+       "      <td>0.826</td>\n",
+       "      <td>0.050</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.098</td>\n",
-       "      <td>0.982</td>\n",
-       "      <td>XGBSE - Debiased BCE</td>\n",
-       "      <td>128.980</td>\n",
+       "      <td>0.113</td>\n",
+       "      <td>0.019</td>\n",
+       "      <td>XGBSE - Stacked Weibull</td>\n",
+       "      <td>2.255</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -637,39 +639,49 @@
        "      <td>0.035</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.097</td>\n",
-       "      <td>0.419</td>\n",
+       "      <td>0.534</td>\n",
        "      <td>XGBSE - Bootstrap Trees</td>\n",
-       "      <td>40.945</td>\n",
+       "      <td>44.736</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.824</td>\n",
+       "      <td>0.038</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.100</td>\n",
+       "      <td>15.662</td>\n",
+       "      <td>XGBSE - Kaplan Neighbors</td>\n",
+       "      <td>1.504</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.824</td>\n",
+       "      <td>0.068</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.108</td>\n",
+       "      <td>0.285</td>\n",
+       "      <td>XGBSE - Debiased BCE</td>\n",
+       "      <td>4.562</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.826</td>\n",
+       "      <td>0.824</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>0.001</td>\n",
+       "      <td>0.002</td>\n",
        "      <td>XGB - Cox</td>\n",
-       "      <td>0.056</td>\n",
+       "      <td>0.375</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.825</td>\n",
+       "      <td>0.823</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - AFT</td>\n",
-       "      <td>0.051</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>0.823</td>\n",
-       "      <td>0.034</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.100</td>\n",
-       "      <td>66.891</td>\n",
-       "      <td>XGBSE - Kaplan Neighbors</td>\n",
-       "      <td>112.969</td>\n",
+       "      <td>0.243</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -677,19 +689,9 @@
        "      <td>0.044</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.101</td>\n",
-       "      <td>0.005</td>\n",
+       "      <td>0.006</td>\n",
        "      <td>XGBSE - Kaplan Tree</td>\n",
-       "      <td>0.506</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.811</td>\n",
-       "      <td>0.067</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.113</td>\n",
-       "      <td>5786.263</td>\n",
-       "      <td>Conditional Survival Forest</td>\n",
-       "      <td>17.024</td>\n",
+       "      <td>0.490</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -697,9 +699,9 @@
        "      <td>0.057</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.136</td>\n",
-       "      <td>0.008</td>\n",
+       "      <td>0.010</td>\n",
        "      <td>Weibull AFT</td>\n",
-       "      <td>0.262</td>\n",
+       "      <td>0.326</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
@@ -707,9 +709,9 @@
        "      <td>0.055</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.135</td>\n",
-       "      <td>0.011</td>\n",
+       "      <td>0.021</td>\n",
        "      <td>Cox-PH</td>\n",
-       "      <td>2.362</td>\n",
+       "      <td>2.267</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -717,26 +719,26 @@
       ],
       "text/plain": [
        "   c-index  dcal_max_dev  dcal_pval    ibs  inference_time  \\\n",
-       "4    0.827         0.044        0.0  0.098           0.982   \n",
-       "7    0.826         0.035        0.0  0.097           0.419   \n",
-       "3    0.826           NaN        NaN    NaN           0.001   \n",
-       "2    0.825           NaN        NaN    NaN           0.001   \n",
-       "5    0.823         0.034        0.0  0.100          66.891   \n",
-       "6    0.821         0.044        0.0  0.101           0.005   \n",
-       "8    0.811         0.067        0.0  0.113        5786.263   \n",
-       "1    0.787         0.057        0.0  0.136           0.008   \n",
-       "0    0.787         0.055        0.0  0.135           0.011   \n",
+       "8    0.826         0.050        0.0  0.113           0.019   \n",
+       "7    0.826         0.035        0.0  0.097           0.534   \n",
+       "5    0.824         0.038        0.0  0.100          15.662   \n",
+       "4    0.824         0.068        0.0  0.108           0.285   \n",
+       "3    0.824           NaN        NaN    NaN           0.002   \n",
+       "2    0.823           NaN        NaN    NaN           0.001   \n",
+       "6    0.821         0.044        0.0  0.101           0.006   \n",
+       "1    0.787         0.057        0.0  0.136           0.010   \n",
+       "0    0.787         0.055        0.0  0.135           0.021   \n",
        "\n",
-       "                         model  training_time  \n",
-       "4         XGBSE - Debiased BCE        128.980  \n",
-       "7      XGBSE - Bootstrap Trees         40.945  \n",
-       "3                    XGB - Cox          0.056  \n",
-       "2                    XGB - AFT          0.051  \n",
-       "5     XGBSE - Kaplan Neighbors        112.969  \n",
-       "6          XGBSE - Kaplan Tree          0.506  \n",
-       "8  Conditional Survival Forest         17.024  \n",
-       "1                  Weibull AFT          0.262  \n",
-       "0                       Cox-PH          2.362  "
+       "                      model  training_time  \n",
+       "8   XGBSE - Stacked Weibull          2.255  \n",
+       "7   XGBSE - Bootstrap Trees         44.736  \n",
+       "5  XGBSE - Kaplan Neighbors          1.504  \n",
+       "4      XGBSE - Debiased BCE          4.562  \n",
+       "3                 XGB - Cox          0.375  \n",
+       "2                 XGB - AFT          0.243  \n",
+       "6       XGBSE - Kaplan Tree          0.490  \n",
+       "1               Weibull AFT          0.326  \n",
+       "0                    Cox-PH          2.267  "
       ]
      },
      "execution_count": 28,
@@ -756,7 +758,7 @@
     {
      "data": {
       "text/plain": [
-       "'| model                       |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:----------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Debiased BCE        |     0.827 |          0.044 |           0 |   0.098 |            0.982 |         128.98  |\\n| XGBSE - Bootstrap Trees     |     0.826 |          0.035 |           0 |   0.097 |            0.419 |          40.945 |\\n| XGB - Cox                   |     0.826 |        nan     |         nan | nan     |            0.001 |           0.056 |\\n| XGB - AFT                   |     0.825 |        nan     |         nan | nan     |            0.001 |           0.051 |\\n| XGBSE - Kaplan Neighbors    |     0.823 |          0.034 |           0 |   0.1   |           66.891 |         112.969 |\\n| XGBSE - Kaplan Tree         |     0.821 |          0.044 |           0 |   0.101 |            0.005 |           0.506 |\\n| Conditional Survival Forest |     0.811 |          0.067 |           0 |   0.113 |         5786.26  |          17.024 |\\n| Weibull AFT                 |     0.787 |          0.057 |           0 |   0.136 |            0.008 |           0.262 |\\n| Cox-PH                      |     0.787 |          0.055 |           0 |   0.135 |            0.011 |           2.362 |'"
+       "'| model                    |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:-------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Stacked Weibull  |     0.826 |          0.05  |           0 |   0.113 |            0.019 |           2.255 |\\n| XGBSE - Bootstrap Trees  |     0.826 |          0.035 |           0 |   0.097 |            0.534 |          44.736 |\\n| XGBSE - Kaplan Neighbors |     0.824 |          0.038 |           0 |   0.1   |           15.662 |           1.504 |\\n| XGBSE - Debiased BCE     |     0.824 |          0.068 |           0 |   0.108 |            0.285 |           4.562 |\\n| XGB - Cox                |     0.824 |        nan     |         nan | nan     |            0.002 |           0.375 |\\n| XGB - AFT                |     0.823 |        nan     |         nan | nan     |            0.001 |           0.243 |\\n| XGBSE - Kaplan Tree      |     0.821 |          0.044 |           0 |   0.101 |            0.006 |           0.49  |\\n| Weibull AFT              |     0.787 |          0.057 |           0 |   0.136 |            0.01  |           0.326 |\\n| Cox-PH                   |     0.787 |          0.055 |           0 |   0.135 |            0.021 |           2.267 |'"
       ]
      },
      "execution_count": 29,
@@ -834,9 +836,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:xgbse]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-xgbse-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -848,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/examples/benchmarks/benchmarks_sac3.ipynb
+++ b/examples/benchmarks/benchmarks_sac3.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -29,12 +29,12 @@
     "import xgboost as xgb\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator\n",
+    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator, XGBSEStackedWeibull\n",
     "from xgbse.converters import convert_data_to_xgb_format, convert_to_structured, convert_y\n",
     "from xgbse.non_parametric import get_time_bins\n",
     "\n",
     "from benchmark import BenchmarkLifelines, BenchmarkXGBoost, BenchmarkXGBSE, BenchmarkPysurvival\n",
-    "from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
+    "#from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
     "\n",
     "# setting seed\n",
     "np.random.seed(42)"
@@ -65,7 +65,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset 'sac3' not created yet. Making dataset...\n",
+      "Done\n"
+     ]
+    }
+   ],
    "source": [
     "from pycox.datasets import sac3\n",
     "sac3_df = sac3.read_df()\n",
@@ -142,9 +151,9 @@
        " 'c-index': 0.6821608577751815,\n",
        " 'ibs': 0.16538314664366988,\n",
        " 'dcal_pval': 2.960248829034621e-63,\n",
-       " 'dcal_max_dev': 0.03529930427043007,\n",
-       " 'training_time': 2.137861967086792,\n",
-       " 'inference_time': 0.036772727966308594}"
+       " 'dcal_max_dev': 0.035299304270430085,\n",
+       " 'training_time': 1.839928150177002,\n",
+       " 'inference_time': 0.03926515579223633}"
       ]
      },
      "execution_count": 8,
@@ -196,10 +205,10 @@
        "{'model': 'Weibull AFT',\n",
        " 'c-index': 0.682028716612183,\n",
        " 'ibs': 0.16549935329896318,\n",
-       " 'dcal_pval': 8.433756927102771e-82,\n",
+       " 'dcal_pval': 8.433756927103006e-82,\n",
        " 'dcal_max_dev': 0.03897261022924145,\n",
-       " 'training_time': 2.0566418170928955,\n",
-       " 'inference_time': 0.03670310974121094}"
+       " 'training_time': 2.307232141494751,\n",
+       " 'inference_time': 0.04311800003051758}"
       ]
      },
      "execution_count": 11,
@@ -258,12 +267,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - AFT',\n",
-       " 'c-index': 0.6714661818988993,\n",
+       " 'c-index': 0.6906307432431247,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.7346310615539551,\n",
-       " 'inference_time': 0.003381967544555664}"
+       " 'training_time': 7.4134063720703125,\n",
+       " 'inference_time': 0.0035758018493652344}"
       ]
      },
      "execution_count": 14,
@@ -295,12 +304,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - Cox',\n",
-       " 'c-index': 0.6700909312669946,\n",
+       " 'c-index': 0.6861246916297403,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.9130971431732178,\n",
-       " 'inference_time': 0.002251148223876953}"
+       " 'training_time': 4.885499000549316,\n",
+       " 'inference_time': 0.0024073123931884766}"
       ]
      },
      "execution_count": 16,
@@ -349,12 +358,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Debiased BCE',\n",
-       " 'c-index': 0.6992551992108598,\n",
-       " 'ibs': 0.1622480403343549,\n",
-       " 'dcal_pval': 1.174853878363636e-100,\n",
-       " 'dcal_max_dev': 0.03820920790971053,\n",
-       " 'training_time': 689.0448880195618,\n",
-       " 'inference_time': 4.066883087158203}"
+       " 'c-index': 0.6898556886301602,\n",
+       " 'ibs': 0.16919460965331368,\n",
+       " 'dcal_pval': 6.341369205743656e-120,\n",
+       " 'dcal_max_dev': 0.044509411533409995,\n",
+       " 'training_time': 47.81409811973572,\n",
+       " 'inference_time': 1.1414539813995361}"
       ]
      },
      "execution_count": 18,
@@ -396,12 +405,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Kaplan Neighbors',\n",
-       " 'c-index': 0.6312882215825405,\n",
-       " 'ibs': 0.18583668971044806,\n",
-       " 'dcal_pval': 1.168283462662509e-69,\n",
-       " 'dcal_max_dev': 0.03795180577534555,\n",
-       " 'training_time': 531.032201051712,\n",
-       " 'inference_time': 1318.8425133228302}"
+       " 'c-index': 0.6663894784009747,\n",
+       " 'ibs': 0.17540358380688037,\n",
+       " 'dcal_pval': 2.553451853967165e-66,\n",
+       " 'dcal_max_dev': 0.03725501925052292,\n",
+       " 'training_time': 36.75927400588989,\n",
+       " 'inference_time': 416.381933927536}"
       ]
      },
      "execution_count": 20,
@@ -447,8 +456,8 @@
        " 'ibs': 0.1914181890695273,\n",
        " 'dcal_pval': 6.061067356778973e-56,\n",
        " 'dcal_max_dev': 0.033688866155989705,\n",
-       " 'training_time': 2.7165441513061523,\n",
-       " 'inference_time': 0.06923484802246094}"
+       " 'training_time': 1.477849006652832,\n",
+       " 'inference_time': 0.0358281135559082}"
       ]
      },
      "execution_count": 22,
@@ -496,8 +505,8 @@
        " 'ibs': 0.16786412434551737,\n",
        " 'dcal_pval': 1.6511792922848247e-98,\n",
        " 'dcal_max_dev': 0.043015745266438726,\n",
-       " 'training_time': 220.7722568511963,\n",
-       " 'inference_time': 3.1344659328460693}"
+       " 'training_time': 164.17341589927673,\n",
+       " 'inference_time': 3.1336629390716553}"
       ]
      },
      "execution_count": 24,
@@ -534,13 +543,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pysurvival"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
@@ -548,13 +550,13 @@
     {
      "data": {
       "text/plain": [
-       "{'model': 'Conditional Survival Forest',\n",
-       " 'c-index': 0.6220749239105159,\n",
-       " 'ibs': 0.18715605994364778,\n",
-       " 'dcal_pval': 7.800830276383053e-98,\n",
-       " 'dcal_max_dev': 0.04440325562340154,\n",
-       " 'training_time': 837.0685200691223,\n",
-       " 'inference_time': 691.9388620853424}"
+       "{'model': 'XGBSE - Stacked Weibull',\n",
+       " 'c-index': 0.6965210329780931,\n",
+       " 'ibs': 0.17058402978933754,\n",
+       " 'dcal_pval': 1.8884687501353905e-76,\n",
+       " 'dcal_max_dev': 0.03968637740815539,\n",
+       " 'training_time': 32.46857404708862,\n",
+       " 'inference_time': 0.152846097946167}"
       ]
      },
      "execution_count": 26,
@@ -563,19 +565,19 @@
     }
    ],
    "source": [
-    "bench_pysurvival = BenchmarkPysurvival(ConditionalSurvivalForestModel(),\n",
+    "bench_xgboost_embedding = BenchmarkXGBSE(XGBSEStackedWeibull(),\n",
     "        df_train,\n",
     "        df_valid,\n",
     "        df_test,\n",
     "        \"event\",\n",
     "        \"duration\",\n",
     "        TIME_BINS,\n",
-    "        \"Conditional Survival Forest\",\n",
-    "\n",
+    "        \"XGBSE - Stacked Weibull\",\n",
+    "        \"survival:aft\",\n",
     ")\n",
-    "bench_pysurvival.train()\n",
-    "pysurvival_results = bench_pysurvival.test()\n",
-    "pysurvival_results"
+    "bench_xgboost_embedding.train()\n",
+    "xgboost_weibull_results = bench_xgboost_embedding.test()\n",
+    "xgboost_weibull_results"
    ]
   },
   {
@@ -584,7 +586,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = results.append(pysurvival_results, ignore_index=True)"
+    "results = results.append(xgboost_weibull_results, ignore_index=True)"
    ]
   },
   {
@@ -624,14 +626,44 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.699</td>\n",
-       "      <td>0.038</td>\n",
+       "      <th>8</th>\n",
+       "      <td>0.697</td>\n",
+       "      <td>0.040</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.162</td>\n",
-       "      <td>4.067</td>\n",
+       "      <td>0.171</td>\n",
+       "      <td>0.153</td>\n",
+       "      <td>XGBSE - Stacked Weibull</td>\n",
+       "      <td>32.469</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.691</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.004</td>\n",
+       "      <td>XGB - AFT</td>\n",
+       "      <td>7.413</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.690</td>\n",
+       "      <td>0.045</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.169</td>\n",
+       "      <td>1.141</td>\n",
        "      <td>XGBSE - Debiased BCE</td>\n",
-       "      <td>689.045</td>\n",
+       "      <td>47.814</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.686</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>XGB - Cox</td>\n",
+       "      <td>4.885</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
@@ -639,9 +671,9 @@
        "      <td>0.035</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.165</td>\n",
-       "      <td>0.037</td>\n",
+       "      <td>0.039</td>\n",
        "      <td>Cox-PH</td>\n",
-       "      <td>2.138</td>\n",
+       "      <td>1.840</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -649,9 +681,9 @@
        "      <td>0.039</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.165</td>\n",
-       "      <td>0.037</td>\n",
+       "      <td>0.043</td>\n",
        "      <td>Weibull AFT</td>\n",
-       "      <td>2.057</td>\n",
+       "      <td>2.307</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -661,37 +693,17 @@
        "      <td>0.168</td>\n",
        "      <td>3.134</td>\n",
        "      <td>XGBSE - Bootstrap Trees</td>\n",
-       "      <td>220.772</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.671</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.003</td>\n",
-       "      <td>XGB - AFT</td>\n",
-       "      <td>0.735</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0.670</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.002</td>\n",
-       "      <td>XGB - Cox</td>\n",
-       "      <td>0.913</td>\n",
+       "      <td>164.173</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>0.631</td>\n",
-       "      <td>0.038</td>\n",
+       "      <td>0.666</td>\n",
+       "      <td>0.037</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.186</td>\n",
-       "      <td>1318.843</td>\n",
+       "      <td>0.175</td>\n",
+       "      <td>416.382</td>\n",
        "      <td>XGBSE - Kaplan Neighbors</td>\n",
-       "      <td>531.032</td>\n",
+       "      <td>36.759</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -699,19 +711,9 @@
        "      <td>0.034</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.191</td>\n",
-       "      <td>0.069</td>\n",
+       "      <td>0.036</td>\n",
        "      <td>XGBSE - Kaplan Tree</td>\n",
-       "      <td>2.717</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.622</td>\n",
-       "      <td>0.044</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.187</td>\n",
-       "      <td>691.939</td>\n",
-       "      <td>Conditional Survival Forest</td>\n",
-       "      <td>837.069</td>\n",
+       "      <td>1.478</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -719,26 +721,26 @@
       ],
       "text/plain": [
        "   c-index  dcal_max_dev  dcal_pval    ibs  inference_time  \\\n",
-       "4    0.699         0.038        0.0  0.162           4.067   \n",
-       "0    0.682         0.035        0.0  0.165           0.037   \n",
-       "1    0.682         0.039        0.0  0.165           0.037   \n",
+       "8    0.697         0.040        0.0  0.171           0.153   \n",
+       "2    0.691           NaN        NaN    NaN           0.004   \n",
+       "4    0.690         0.045        0.0  0.169           1.141   \n",
+       "3    0.686           NaN        NaN    NaN           0.002   \n",
+       "0    0.682         0.035        0.0  0.165           0.039   \n",
+       "1    0.682         0.039        0.0  0.165           0.043   \n",
        "7    0.677         0.043        0.0  0.168           3.134   \n",
-       "2    0.671           NaN        NaN    NaN           0.003   \n",
-       "3    0.670           NaN        NaN    NaN           0.002   \n",
-       "5    0.631         0.038        0.0  0.186        1318.843   \n",
-       "6    0.631         0.034        0.0  0.191           0.069   \n",
-       "8    0.622         0.044        0.0  0.187         691.939   \n",
+       "5    0.666         0.037        0.0  0.175         416.382   \n",
+       "6    0.631         0.034        0.0  0.191           0.036   \n",
        "\n",
-       "                         model  training_time  \n",
-       "4         XGBSE - Debiased BCE        689.045  \n",
-       "0                       Cox-PH          2.138  \n",
-       "1                  Weibull AFT          2.057  \n",
-       "7      XGBSE - Bootstrap Trees        220.772  \n",
-       "2                    XGB - AFT          0.735  \n",
-       "3                    XGB - Cox          0.913  \n",
-       "5     XGBSE - Kaplan Neighbors        531.032  \n",
-       "6          XGBSE - Kaplan Tree          2.717  \n",
-       "8  Conditional Survival Forest        837.069  "
+       "                      model  training_time  \n",
+       "8   XGBSE - Stacked Weibull         32.469  \n",
+       "2                 XGB - AFT          7.413  \n",
+       "4      XGBSE - Debiased BCE         47.814  \n",
+       "3                 XGB - Cox          4.885  \n",
+       "0                    Cox-PH          1.840  \n",
+       "1               Weibull AFT          2.307  \n",
+       "7   XGBSE - Bootstrap Trees        164.173  \n",
+       "5  XGBSE - Kaplan Neighbors         36.759  \n",
+       "6       XGBSE - Kaplan Tree          1.478  "
       ]
      },
      "execution_count": 28,
@@ -758,7 +760,7 @@
     {
      "data": {
       "text/plain": [
-       "'| model                       |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:----------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Debiased BCE        |     0.699 |          0.038 |           0 |   0.162 |            4.067 |         689.045 |\\n| Cox-PH                      |     0.682 |          0.035 |           0 |   0.165 |            0.037 |           2.138 |\\n| Weibull AFT                 |     0.682 |          0.039 |           0 |   0.165 |            0.037 |           2.057 |\\n| XGBSE - Bootstrap Trees     |     0.677 |          0.043 |           0 |   0.168 |            3.134 |         220.772 |\\n| XGB - AFT                   |     0.671 |        nan     |         nan | nan     |            0.003 |           0.735 |\\n| XGB - Cox                   |     0.67  |        nan     |         nan | nan     |            0.002 |           0.913 |\\n| XGBSE - Kaplan Neighbors    |     0.631 |          0.038 |           0 |   0.186 |         1318.84  |         531.032 |\\n| XGBSE - Kaplan Tree         |     0.631 |          0.034 |           0 |   0.191 |            0.069 |           2.717 |\\n| Conditional Survival Forest |     0.622 |          0.044 |           0 |   0.187 |          691.939 |         837.069 |'"
+       "'| model                    |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:-------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Stacked Weibull  |     0.697 |          0.04  |           0 |   0.171 |            0.153 |          32.469 |\\n| XGB - AFT                |     0.691 |        nan     |         nan | nan     |            0.004 |           7.413 |\\n| XGBSE - Debiased BCE     |     0.69  |          0.045 |           0 |   0.169 |            1.141 |          47.814 |\\n| XGB - Cox                |     0.686 |        nan     |         nan | nan     |            0.002 |           4.885 |\\n| Cox-PH                   |     0.682 |          0.035 |           0 |   0.165 |            0.039 |           1.84  |\\n| Weibull AFT              |     0.682 |          0.039 |           0 |   0.165 |            0.043 |           2.307 |\\n| XGBSE - Bootstrap Trees  |     0.677 |          0.043 |           0 |   0.168 |            3.134 |         164.173 |\\n| XGBSE - Kaplan Neighbors |     0.666 |          0.037 |           0 |   0.175 |          416.382 |          36.759 |\\n| XGBSE - Kaplan Tree      |     0.631 |          0.034 |           0 |   0.191 |            0.036 |           1.478 |'"
       ]
      },
      "execution_count": 29,
@@ -850,9 +852,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:xgbse]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-xgbse-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -864,7 +866,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/examples/benchmarks/benchmarks_support.ipynb
+++ b/examples/benchmarks/benchmarks_support.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -29,12 +29,12 @@
     "import xgboost as xgb\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator\n",
+    "from xgbse import XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEDebiasedBCE, XGBSEBootstrapEstimator, XGBSEStackedWeibull\n",
     "from xgbse.converters import convert_data_to_xgb_format, convert_to_structured, convert_y\n",
     "from xgbse.non_parametric import get_time_bins\n",
     "\n",
     "from benchmark import BenchmarkLifelines, BenchmarkXGBoost, BenchmarkXGBSE, BenchmarkPysurvival\n",
-    "from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
+    "#from pysurvival.models.survival_forest import ConditionalSurvivalForestModel\n",
     "\n",
     "# setting seed\n",
     "np.random.seed(42)"
@@ -74,7 +74,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset 'support' not locally available. Downloading...\n",
+      "Done\n"
+     ]
+    }
+   ],
    "source": [
     "support_df = support.read_df()\n",
     "df_train, df_valid, df_test = split_train_test_valid(support_df)\n",
@@ -83,13 +92,6 @@
     "E_train = df_train.event\n",
     "TIME_BINS = time_bins = get_time_bins(T_train, E_train, size=30)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -156,8 +158,8 @@
        " 'ibs': 0.2013043483549938,\n",
        " 'dcal_pval': 0.0,\n",
        " 'dcal_max_dev': 0.16042116729003866,\n",
-       " 'training_time': 0.5187549591064453,\n",
-       " 'inference_time': 0.009529829025268555}"
+       " 'training_time': 0.46547985076904297,\n",
+       " 'inference_time': 0.00558018684387207}"
       ]
      },
      "execution_count": 9,
@@ -208,11 +210,11 @@
       "text/plain": [
        "{'model': 'Weibull AFT',\n",
        " 'c-index': 0.5764595917903831,\n",
-       " 'ibs': 0.20147880877502886,\n",
-       " 'dcal_pval': 5.912690299687692e-252,\n",
-       " 'dcal_max_dev': 0.13831859544149858,\n",
-       " 'training_time': 0.6235389709472656,\n",
-       " 'inference_time': 0.008682012557983398}"
+       " 'ibs': 0.201478808775029,\n",
+       " 'dcal_pval': 5.912690299669512e-252,\n",
+       " 'dcal_max_dev': 0.13831859544149952,\n",
+       " 'training_time': 0.4608640670776367,\n",
+       " 'inference_time': 0.006687164306640625}"
       ]
      },
      "execution_count": 12,
@@ -271,12 +273,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - AFT',\n",
-       " 'c-index': 0.6118077667273784,\n",
+       " 'c-index': 0.608615671766739,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.05042719841003418,\n",
-       " 'inference_time': 0.0008549690246582031}"
+       " 'training_time': 0.1367959976196289,\n",
+       " 'inference_time': 0.0008289813995361328}"
       ]
      },
      "execution_count": 15,
@@ -308,12 +310,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGB - Cox',\n",
-       " 'c-index': 0.61197556100068,\n",
+       " 'c-index': 0.6103962565498003,\n",
        " 'ibs': nan,\n",
        " 'dcal_pval': nan,\n",
        " 'dcal_max_dev': nan,\n",
-       " 'training_time': 0.13672184944152832,\n",
-       " 'inference_time': 0.0010209083557128906}"
+       " 'training_time': 0.06884503364562988,\n",
+       " 'inference_time': 0.0008327960968017578}"
       ]
      },
      "execution_count": 17,
@@ -362,12 +364,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Debiased BCE',\n",
-       " 'c-index': 0.607062937775623,\n",
-       " 'ibs': 0.189858717682179,\n",
-       " 'dcal_pval': 8.767402398701876e-189,\n",
-       " 'dcal_max_dev': 0.11941058998551468,\n",
-       " 'training_time': 62.01675295829773,\n",
-       " 'inference_time': 1.2210862636566162}"
+       " 'c-index': 0.6170781812119915,\n",
+       " 'ibs': 0.18848515920234526,\n",
+       " 'dcal_pval': 1.2695847564787107e-261,\n",
+       " 'dcal_max_dev': 0.13931966387559408,\n",
+       " 'training_time': 3.851815938949585,\n",
+       " 'inference_time': 0.27188897132873535}"
       ]
      },
      "execution_count": 19,
@@ -409,12 +411,12 @@
      "data": {
       "text/plain": [
        "{'model': 'XGBSE - Kaplan Neighbors',\n",
-       " 'c-index': 0.5777793792849416,\n",
-       " 'ibs': 0.20156917507339067,\n",
-       " 'dcal_pval': 6.99924919299361e-176,\n",
-       " 'dcal_max_dev': 0.11043982034195823,\n",
-       " 'training_time': 49.236324310302734,\n",
-       " 'inference_time': 8.93327784538269}"
+       " 'c-index': 0.600916790055514,\n",
+       " 'ibs': 0.19707657293093728,\n",
+       " 'dcal_pval': 1.4246814978646604e-123,\n",
+       " 'dcal_max_dev': 0.09887323943661973,\n",
+       " 'training_time': 0.7519700527191162,\n",
+       " 'inference_time': 1.4877333641052246}"
       ]
      },
      "execution_count": 21,
@@ -460,8 +462,8 @@
        " 'ibs': 0.20288464464793987,\n",
        " 'dcal_pval': 1.360307803727658e-142,\n",
        " 'dcal_max_dev': 0.0965224071702945,\n",
-       " 'training_time': 0.19405484199523926,\n",
-       " 'inference_time': 0.005036115646362305}"
+       " 'training_time': 0.1490190029144287,\n",
+       " 'inference_time': 0.003683805465698242}"
       ]
      },
      "execution_count": 23,
@@ -509,8 +511,8 @@
        " 'ibs': 0.18781453318160898,\n",
        " 'dcal_pval': 2.711414876542169e-197,\n",
        " 'dcal_max_dev': 0.10253653541171698,\n",
-       " 'training_time': 19.81351399421692,\n",
-       " 'inference_time': 0.5238931179046631}"
+       " 'training_time': 18.202492237091064,\n",
+       " 'inference_time': 0.3706178665161133}"
       ]
      },
      "execution_count": 25,
@@ -547,13 +549,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Pysurvival"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {},
@@ -561,13 +556,13 @@
     {
      "data": {
       "text/plain": [
-       "{'model': 'Conditional Survival Forest',\n",
-       " 'c-index': 0.5947109497956622,\n",
-       " 'ibs': 0.1946863785642482,\n",
-       " 'dcal_pval': 0.0,\n",
-       " 'dcal_max_dev': 0.16581709491434668,\n",
-       " 'training_time': 2.6257541179656982,\n",
-       " 'inference_time': 115.48593997955322}"
+       "{'model': 'XGBSE - Stacked Weibull',\n",
+       " 'c-index': 0.6209880425651486,\n",
+       " 'ibs': 0.19789744262262765,\n",
+       " 'dcal_pval': 1.1365179764288005e-136,\n",
+       " 'dcal_max_dev': 0.0922466248054489,\n",
+       " 'training_time': 0.9544377326965332,\n",
+       " 'inference_time': 0.012730121612548828}"
       ]
      },
      "execution_count": 27,
@@ -576,19 +571,19 @@
     }
    ],
    "source": [
-    "bench_pysurvival = BenchmarkPysurvival(ConditionalSurvivalForestModel(),\n",
+    "bench_xgboost_embedding = BenchmarkXGBSE(XGBSEStackedWeibull(),\n",
     "        df_train,\n",
     "        df_valid,\n",
     "        df_test,\n",
     "        \"event\",\n",
     "        \"duration\",\n",
     "        TIME_BINS,\n",
-    "        \"Conditional Survival Forest\",\n",
-    "\n",
+    "        \"XGBSE - Stacked Weibull\",\n",
+    "        \"survival:aft\",\n",
     ")\n",
-    "bench_pysurvival.train()\n",
-    "pysurvival_results = bench_pysurvival.test()\n",
-    "pysurvival_results"
+    "bench_xgboost_embedding.train()\n",
+    "xgboost_weibull_results = bench_xgboost_embedding.test()\n",
+    "xgboost_weibull_results"
    ]
   },
   {
@@ -597,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = results.append(pysurvival_results, ignore_index=True)"
+    "results = results.append(xgboost_weibull_results, ignore_index=True)"
    ]
   },
   {
@@ -637,24 +632,44 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.621</td>\n",
+       "      <td>0.092</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.198</td>\n",
+       "      <td>0.013</td>\n",
+       "      <td>XGBSE - Stacked Weibull</td>\n",
+       "      <td>0.954</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.617</td>\n",
+       "      <td>0.139</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.188</td>\n",
+       "      <td>0.272</td>\n",
+       "      <td>XGBSE - Debiased BCE</td>\n",
+       "      <td>3.852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.612</td>\n",
+       "      <td>0.610</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - Cox</td>\n",
-       "      <td>0.137</td>\n",
+       "      <td>0.069</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.612</td>\n",
+       "      <td>0.609</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.001</td>\n",
        "      <td>XGB - AFT</td>\n",
-       "      <td>0.050</td>\n",
+       "      <td>0.137</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -662,19 +677,19 @@
        "      <td>0.103</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.188</td>\n",
-       "      <td>0.524</td>\n",
+       "      <td>0.371</td>\n",
        "      <td>XGBSE - Bootstrap Trees</td>\n",
-       "      <td>19.814</td>\n",
+       "      <td>18.202</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.607</td>\n",
-       "      <td>0.119</td>\n",
+       "      <th>5</th>\n",
+       "      <td>0.601</td>\n",
+       "      <td>0.099</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.190</td>\n",
-       "      <td>1.221</td>\n",
-       "      <td>XGBSE - Debiased BCE</td>\n",
-       "      <td>62.017</td>\n",
+       "      <td>0.197</td>\n",
+       "      <td>1.488</td>\n",
+       "      <td>XGBSE - Kaplan Neighbors</td>\n",
+       "      <td>0.752</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -682,19 +697,9 @@
        "      <td>0.097</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.203</td>\n",
-       "      <td>0.005</td>\n",
+       "      <td>0.004</td>\n",
        "      <td>XGBSE - Kaplan Tree</td>\n",
-       "      <td>0.194</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.595</td>\n",
-       "      <td>0.166</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.195</td>\n",
-       "      <td>115.486</td>\n",
-       "      <td>Conditional Survival Forest</td>\n",
-       "      <td>2.626</td>\n",
+       "      <td>0.149</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
@@ -702,19 +707,9 @@
        "      <td>0.160</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.201</td>\n",
-       "      <td>0.010</td>\n",
+       "      <td>0.006</td>\n",
        "      <td>Cox-PH</td>\n",
-       "      <td>0.519</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>0.578</td>\n",
-       "      <td>0.110</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.202</td>\n",
-       "      <td>8.933</td>\n",
-       "      <td>XGBSE - Kaplan Neighbors</td>\n",
-       "      <td>49.236</td>\n",
+       "      <td>0.465</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -722,9 +717,9 @@
        "      <td>0.138</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.201</td>\n",
-       "      <td>0.009</td>\n",
+       "      <td>0.007</td>\n",
        "      <td>Weibull AFT</td>\n",
-       "      <td>0.624</td>\n",
+       "      <td>0.461</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -732,26 +727,26 @@
       ],
       "text/plain": [
        "   c-index  dcal_max_dev  dcal_pval    ibs  inference_time  \\\n",
-       "3    0.612           NaN        NaN    NaN           0.001   \n",
-       "2    0.612           NaN        NaN    NaN           0.001   \n",
-       "7    0.607         0.103        0.0  0.188           0.524   \n",
-       "4    0.607         0.119        0.0  0.190           1.221   \n",
-       "6    0.598         0.097        0.0  0.203           0.005   \n",
-       "8    0.595         0.166        0.0  0.195         115.486   \n",
-       "0    0.578         0.160        0.0  0.201           0.010   \n",
-       "5    0.578         0.110        0.0  0.202           8.933   \n",
-       "1    0.576         0.138        0.0  0.201           0.009   \n",
+       "8    0.621         0.092        0.0  0.198           0.013   \n",
+       "4    0.617         0.139        0.0  0.188           0.272   \n",
+       "3    0.610           NaN        NaN    NaN           0.001   \n",
+       "2    0.609           NaN        NaN    NaN           0.001   \n",
+       "7    0.607         0.103        0.0  0.188           0.371   \n",
+       "5    0.601         0.099        0.0  0.197           1.488   \n",
+       "6    0.598         0.097        0.0  0.203           0.004   \n",
+       "0    0.578         0.160        0.0  0.201           0.006   \n",
+       "1    0.576         0.138        0.0  0.201           0.007   \n",
        "\n",
-       "                         model  training_time  \n",
-       "3                    XGB - Cox          0.137  \n",
-       "2                    XGB - AFT          0.050  \n",
-       "7      XGBSE - Bootstrap Trees         19.814  \n",
-       "4         XGBSE - Debiased BCE         62.017  \n",
-       "6          XGBSE - Kaplan Tree          0.194  \n",
-       "8  Conditional Survival Forest          2.626  \n",
-       "0                       Cox-PH          0.519  \n",
-       "5     XGBSE - Kaplan Neighbors         49.236  \n",
-       "1                  Weibull AFT          0.624  "
+       "                      model  training_time  \n",
+       "8   XGBSE - Stacked Weibull          0.954  \n",
+       "4      XGBSE - Debiased BCE          3.852  \n",
+       "3                 XGB - Cox          0.069  \n",
+       "2                 XGB - AFT          0.137  \n",
+       "7   XGBSE - Bootstrap Trees         18.202  \n",
+       "5  XGBSE - Kaplan Neighbors          0.752  \n",
+       "6       XGBSE - Kaplan Tree          0.149  \n",
+       "0                    Cox-PH          0.465  \n",
+       "1               Weibull AFT          0.461  "
       ]
      },
      "execution_count": 29,
@@ -771,7 +766,7 @@
     {
      "data": {
       "text/plain": [
-       "'| model                       |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:----------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGB - Cox                   |     0.612 |        nan     |         nan | nan     |            0.001 |           0.137 |\\n| XGB - AFT                   |     0.612 |        nan     |         nan | nan     |            0.001 |           0.05  |\\n| XGBSE - Bootstrap Trees     |     0.607 |          0.103 |           0 |   0.188 |            0.524 |          19.814 |\\n| XGBSE - Debiased BCE        |     0.607 |          0.119 |           0 |   0.19  |            1.221 |          62.017 |\\n| XGBSE - Kaplan Tree         |     0.598 |          0.097 |           0 |   0.203 |            0.005 |           0.194 |\\n| Conditional Survival Forest |     0.595 |          0.166 |           0 |   0.195 |          115.486 |           2.626 |\\n| Cox-PH                      |     0.578 |          0.16  |           0 |   0.201 |            0.01  |           0.519 |\\n| XGBSE - Kaplan Neighbors    |     0.578 |          0.11  |           0 |   0.202 |            8.933 |          49.236 |\\n| Weibull AFT                 |     0.576 |          0.138 |           0 |   0.201 |            0.009 |           0.624 |'"
+       "'| model                    |   c-index |   dcal_max_dev |   dcal_pval |     ibs |   inference_time |   training_time |\\n|:-------------------------|----------:|---------------:|------------:|--------:|-----------------:|----------------:|\\n| XGBSE - Stacked Weibull  |     0.621 |          0.092 |           0 |   0.198 |            0.013 |           0.954 |\\n| XGBSE - Debiased BCE     |     0.617 |          0.139 |           0 |   0.188 |            0.272 |           3.852 |\\n| XGB - Cox                |     0.61  |        nan     |         nan | nan     |            0.001 |           0.069 |\\n| XGB - AFT                |     0.609 |        nan     |         nan | nan     |            0.001 |           0.137 |\\n| XGBSE - Bootstrap Trees  |     0.607 |          0.103 |           0 |   0.188 |            0.371 |          18.202 |\\n| XGBSE - Kaplan Neighbors |     0.601 |          0.099 |           0 |   0.197 |            1.488 |           0.752 |\\n| XGBSE - Kaplan Tree      |     0.598 |          0.097 |           0 |   0.203 |            0.004 |           0.149 |\\n| Cox-PH                   |     0.578 |          0.16  |           0 |   0.201 |            0.006 |           0.465 |\\n| Weibull AFT              |     0.576 |          0.138 |           0 |   0.201 |            0.007 |           0.461 |'"
       ]
      },
      "execution_count": 30,
@@ -852,20 +847,13 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:xgbse]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-xgbse-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -877,7 +865,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -1,7 +1,12 @@
 import pytest
 
 from tests.data import get_data
-from xgbse import XGBSEDebiasedBCE, XGBSEKaplanNeighbors, XGBSEKaplanTree
+from xgbse import (
+    XGBSEDebiasedBCE,
+    XGBSEKaplanNeighbors,
+    XGBSEKaplanTree,
+    XGBSEStackedWeibull,
+)
 
 (
     X_train,
@@ -33,7 +38,9 @@ def assert_neighbors(df, comps, n_neighbors):
     assert df.varcof.mean() < 1
 
 
-@pytest.mark.parametrize("model", [XGBSEDebiasedBCE, XGBSEKaplanNeighbors])
+@pytest.mark.parametrize(
+    "model", [XGBSEDebiasedBCE, XGBSEKaplanNeighbors, XGBSEStackedWeibull]
+)
 def test_model_neighbors_persist_false(model):
     n_neighbors = 30
     test_feature = "pnodes"
@@ -68,7 +75,8 @@ def test_model_neighbors_persist_false(model):
 
 
 @pytest.mark.parametrize(
-    "model", [XGBSEDebiasedBCE, XGBSEKaplanNeighbors, XGBSEKaplanTree]
+    "model",
+    [XGBSEDebiasedBCE, XGBSEKaplanNeighbors, XGBSEKaplanTree, XGBSEStackedWeibull],
 )
 def test_model_neighbors_persist_true(model):
     n_neighbors = 30

--- a/tests/test_survival_curves.py
+++ b/tests/test_survival_curves.py
@@ -7,6 +7,7 @@ from xgbse import (
     XGBSEDebiasedBCE,
     XGBSEKaplanNeighbors,
     XGBSEKaplanTree,
+    XGBSEStackedWeibull,
 )
 
 (
@@ -45,7 +46,9 @@ def assert_survival_curve(xgbse, test, preds, cindex):
     assert preds.shape[1] == xgbse.time_bins.shape[0]
 
 
-@pytest.mark.parametrize("model", [XGBSEDebiasedBCE, XGBSEKaplanNeighbors])
+@pytest.mark.parametrize(
+    "model", [XGBSEDebiasedBCE, XGBSEKaplanNeighbors, XGBSEStackedWeibull]
+)
 def test_survival_curve(model):
     xgbse = model()
 

--- a/xgbse/__init__.py
+++ b/xgbse/__init__.py
@@ -2,6 +2,7 @@
 
 from ._debiased_bce import XGBSEDebiasedBCE
 from ._kaplan_neighbors import XGBSEKaplanNeighbors, XGBSEKaplanTree
+from ._stacked_weibull import XGBSEStackedWeibull
 from ._meta import XGBSEBootstrapEstimator
 
 
@@ -11,5 +12,6 @@ __all__ = [
     "XGBSEDebiasedBCE",
     "XGBSEKaplanNeighbors",
     "XGBSEKaplanTree",
+    "XGBSEStackedWeibull",
     "XGBSEBootstrapEstimator",
 ]

--- a/xgbse/_stacked_weibull.py
+++ b/xgbse/_stacked_weibull.py
@@ -1,0 +1,202 @@
+import numpy as np
+import pandas as pd
+import xgboost as xgb
+from lifelines import WeibullAFTFitter
+from sklearn.neighbors import BallTree
+
+# lib utils
+from xgbse._base import XGBSEBaseEstimator
+from xgbse.converters import convert_data_to_xgb_format, convert_y
+
+# at which percentiles will the KM predict
+from xgbse.non_parametric import get_time_bins, calculate_interval_failures
+
+KM_PERCENTILES = np.linspace(0, 1, 11)
+
+DEFAULT_PARAMS = {
+    "objective": "survival:aft",
+    "eval_metric": "aft-nloglik",
+    "aft_loss_distribution": "normal",
+    "aft_loss_distribution_scale": 1,
+    "tree_method": "hist",
+    "learning_rate": 5e-2,
+    "max_depth": 8,
+    "booster": "dart",
+    "subsample": 0.5,
+    "min_child_weight": 50,
+    "colsample_bynode": 0.5,
+}
+
+DEFAULT_PARAMS_WEIBULL = {}
+
+
+class XGBSEStackedWeibull(XGBSEBaseEstimator):
+    """
+    Perform stacking of a XGBoost survival model with a Weibull AFT parametric model.
+    The XGBoost fits the data and then predicts a value that is interpreted as a risk metric.
+    This risk metric is fed to the Weibull regression which uses it as its only independent variable.
+    Thus, we can get the benefit of XGBoost discrimination power alongside the Weibull AFT
+    statistical rigor (calibrated survival curves, confidence intervals)
+    """
+
+    def __init__(
+        self,
+        xgb_params=DEFAULT_PARAMS,
+        weibull_params=DEFAULT_PARAMS_WEIBULL,
+        n_jobs=-1,
+    ):
+        """
+        Construct XGBSEStackedWeibull instance
+
+        Args:
+            xgb_params (Dict): parameters for XGBoost model, see
+                https://xgboost.readthedocs.io/en/latest/parameter.html
+
+            weibull_params (Dict): parameters for Weibull Regerssion model, see
+                https://lifelines.readthedocs.io/en/latest/fitters/regression/WeibullAFTFitter.html
+
+
+        """
+        self.xgb_params = xgb_params
+        self.weibull_params = weibull_params
+        self.persist_train = False
+
+    def fit(
+        self,
+        X,
+        y,
+        num_boost_round=1000,
+        validation_data=None,
+        early_stopping_rounds=None,
+        verbose_eval=0,
+        persist_train=False,
+        index_id=None,
+        time_bins=None,
+    ):
+        """
+        Fit XGBoost model to predict a value that is interpreted as a risk metric.
+        Fit Weibull Regression model using risk metric as only independent variable.
+
+        Args:
+            X ([pd.DataFrame, np.array]): features to be used while fitting XGBoost model
+
+            y (structured array(numpy.bool_, numpy.number)): binary event indicator as first field,
+                and time of event or time of censoring as second field.
+
+            num_boost_round (Int): Number of boosting iterations.
+
+            validation_data (Tuple): Validation data in the format of a list of tuples [(X, y)]
+                if user desires to use early stopping
+
+            early_stopping_rounds (Int): Activates early stopping.
+                Validation metric needs to improve at least once
+                in every **early_stopping_rounds** round(s) to continue training.
+                See xgboost.train documentation.
+
+            verbose_eval ([Bool, Int]): level of verbosity. See xgboost.train documentation.
+
+            persist_train (Bool): whether or not to persist training data to use explainability
+                through prototypes
+
+            index_id (pd.Index): user defined index if intended to use explainability
+                through prototypes
+
+            time_bins (np.array): specified time windows to use when making survival predictions
+
+
+        Returns:
+            XGBSEStackedWeibull: Trained XGBSEStackedWeibull instance
+        """
+
+        E_train, T_train = convert_y(y)
+        if time_bins is None:
+            time_bins = get_time_bins(T_train, E_train)
+        self.time_bins = time_bins
+
+        # converting data to xgb format
+        dtrain = convert_data_to_xgb_format(X, y, self.xgb_params["objective"])
+
+        # converting validation data to xgb format
+        evals = ()
+        if validation_data:
+            X_val, y_val = validation_data
+            dvalid = convert_data_to_xgb_format(
+                X_val, y_val, self.xgb_params["objective"]
+            )
+            evals = [(dvalid, "validation")]
+
+        # training XGB
+        self.bst = xgb.train(
+            self.xgb_params,
+            dtrain,
+            num_boost_round=num_boost_round,
+            early_stopping_rounds=early_stopping_rounds,
+            evals=evals,
+            verbose_eval=verbose_eval,
+        )
+
+        # predicting risk from XGBoost
+        train_risk = self.bst.predict(dtrain)
+
+        # replacing 0 by minimum positive value in df
+        # so Weibull can be fitted
+        min_positive_value = T_train[T_train > 0].min()
+        T_train = np.clip(T_train, min_positive_value, None)
+
+        # creating df to use lifelines API
+        weibull_train_df = pd.DataFrame(
+            {"risk": train_risk, "duration": T_train, "event": E_train}
+        )
+
+        # fitting weibull aft
+        self.weibull_aft = WeibullAFTFitter(**self.weibull_params)
+        self.weibull_aft.fit(weibull_train_df, "duration", "event", ancillary=True)
+
+        if persist_train:
+            self.persist_train = True
+            if index_id is None:
+                index_id = X.index.copy()
+
+            index_leaves = self.bst.predict(dtrain, pred_leaf=True)
+            self.tree = BallTree(index_leaves, metric="hamming")
+
+        self.index_id = index_id
+
+        return self
+
+    def predict(self, X, return_interval_probs=False):
+        """
+        Predicts survival probabilities using the XGBoost + Weibull AFT stacking pipeline.
+
+        Args:
+            X (pd.DataFrame): Dataframe of features to be used as input for the
+                XGBoost model.
+
+            return_interval_probs (Bool): Boolean indicating if interval probabilities are
+                supposed to be returned. If False the cumulative survival is returned.
+                Default is False.
+
+        Returns:
+            pd.DataFrame: A dataframe of survival probabilities
+            for all times (columns), from a time_bins array, for all samples of X
+            (rows). If return_interval_probs is True, the interval probabilities are returned
+            instead of the cumulative survival probabilities.
+        """
+
+        # converting to xgb format
+        d_matrix = xgb.DMatrix(X)
+
+        # getting leaves and extracting neighbors
+        risk = self.bst.predict(d_matrix)
+        weibull_score_df = pd.DataFrame({"risk": risk})
+
+        # predicting from logistic regression artifacts
+
+        preds_df = self.weibull_aft.predict_survival_function(
+            weibull_score_df, self.time_bins
+        ).T
+
+        if return_interval_probs:
+            preds_df = calculate_interval_failures(preds_df)
+
+        return preds_df


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Todo list
- [x] create new method: XGBSEStackedWeibull
- [x] add it to init and tests
- [x] add it to benchmarks 
- [ ] Define new version for lib
- [ ] add XGBSEStackedWeibull to documentation
- [ ] Update benchmarks in documentation

### Background context
Feedback from community showed the need for improving speed in XGBSEDebiasedBCE and a praise for Weibull regression. It was easy to implement a stacked weibull method that can work as a faster alternative to XGBSEDebiasedBCE and has great performance (best C-index in 4/5 benchmarks).

### Description of the changes proposed in the pull request
Split by commits:
1. Added a new script where XGBSEStackedWeibull is defined, very similarly to XGBSEDebiasedBCE
2. Added XGBSEStackedWeibull to init
3. Added XGBSEStackedWeibull to tests
4. Changed benchmark code so XGBoost and XGBSE work with early stopping (results were distorted because of that)
5. Reran the benchmarks notebooks, adding XGBSEStackedWeibull and removing PySurvival (as it was almost impossible to install)

### Remaining problems or questions
Need to decide package version after this update (0.2.2?). Need to update docs.